### PR TITLE
separate cmd 'call_service' from **KWARGS before 'send_command

### DIFF
--- a/hass_client/client.py
+++ b/hass_client/client.py
@@ -165,12 +165,12 @@ class HomeAssistantClient:
         """
         if not self.connected:
             raise NotConnected("Please call connect first.")
-        msg = {"type": "call_service", "domain": domain, "service": service}
+        msg = {"domain": domain, "service": service}
         if service_data:
             msg["service_data"] = service_data
         if target:
             msg["target"] = target
-        return await self.send_command(msg)
+        return await self.send_command("call_service", **msg)
 
     async def get_states(self) -> list[State]:
         """Get dump of the current states within Home Assistant."""


### PR DESCRIPTION
In order to get the "call_service" function to work, I needed to separate the command ("call_service") from the rest of the arguments, after which the "send_command" function worked properly.