### PR TITLE
Fix handling of "message too large" with autoscaling

### DIFF
--- a/hass_client/exceptions.py
+++ b/hass_client/exceptions.py
@@ -32,6 +32,8 @@ class ConnectionFailed(TransportError):
             return
         super().__init__(f"{error}", error)
 
+class ConnectionFailedDueToLargeMessage(ConnectionFailed):
+    """Exception raised when an established connection fails due to an oversize message"""
 
 class NotFoundError(BaseHassClientError):
     """Exception that is raised when an entity can't be found."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=62.3", "wheel~=0.37.1"]
+requires = ["setuptools~=64.0", "wheel~=0.37.1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Modify the default message pump loop to automatically increase the message size and wait for reconnect when using get* commands (hereby in the category of "retryable" commands).

This fixes getting data for large numbers of entities (my HA instance has 47000+ out of the box).

To facilitate this, more information is now returned from the client object when cancelling errors - namely we bubble the error which is causing the cancellation through to the task cancellation, which allows the caller to make an informed choice about what to do (in this case, wait and retry so long as the error is only "message too long").

The other change is to add an event for `connected` - this lets our retryable processes efficiently wait for the reconnect loop to succeed (which should be immediate with the message size problem).

setuptools is also bumped to version 64.0 which supports proper editable installs.