### PR TITLE
Fix unsubscribe()'s permanent KeyError

### DIFF
--- a/hass_client/client.py
+++ b/hass_client/client.py
@@ -254,9 +254,9 @@ class HomeAssistantClient:
         def remove_listener():
             self._subscriptions.pop(message_id)
             # try to unsubscribe
-            if "subscribe" not in message_base["type"]:
+            if "subscribe" not in message_base["command"]:
                 return
-            unsub_command = message_base["type"].replace("subscribe", "unsubscribe")
+            unsub_command = message_base["command"].replace("subscribe", "unsubscribe")
             asyncio.create_task(self.send_command_no_wait(unsub_command, subscription=message_id))
 
         return remove_listener


### PR DESCRIPTION
  File "Z:\xxx\.venv\Lib\site-packages\hass_client\client.py", line 257, in remove_listener
    if "subscribe" not in message_base["type"]:
                          ~~~~~~~~~~~~^^^^^^^^
KeyError: 'type'