### PR TITLE
Fix: don't throw warning for unsubscribe results

### DIFF
--- a/hass_client/client.py
+++ b/hass_client/client.py
@@ -365,7 +365,7 @@ class HomeAssistantClient:
             future = self._result_futures.get(msg["id"])
 
             if future is None:
-                LOGGER.warning("Received result for unknown message with ID: %s", msg["id"])
+                LOGGER.debug("Received result for unknown message with ID: %s", msg["id"])
                 return
 
             if msg["success"]:

--- a/hass_client/client.py
+++ b/hass_client/client.py
@@ -257,7 +257,7 @@ class HomeAssistantClient:
             if "subscribe" not in message_base["type"]:
                 return
             unsub_command = message_base["type"].replace("subscribe", "unsubscribe")
-            asyncio.create_task(self.send_command_no_wait(unsub_command, subscription=message_id))
+            asyncio.create_task(self.send_command(unsub_command, subscription=message_id))
 
         return remove_listener
 

--- a/hass_client/client.py
+++ b/hass_client/client.py
@@ -257,7 +257,7 @@ class HomeAssistantClient:
             if "subscribe" not in message_base["type"]:
                 return
             unsub_command = message_base["type"].replace("subscribe", "unsubscribe")
-            asyncio.create_task(self.send_command(unsub_command, subscription=message_id))
+            asyncio.create_task(self.send_command_no_wait(unsub_command, subscription=message_id))
 
         return remove_listener
 


### PR DESCRIPTION
Without waiting for the reply, it always created a warning: Received result for unknown message with ID: x