### PR TITLE
Enhancement, BREAKING CHANGE - await for the unsubscribe()'s reply before closing the connection

### DIFF
--- a/hass_client/client.py
+++ b/hass_client/client.py
@@ -251,13 +251,13 @@ class HomeAssistantClient:
         await self.send_command(**message_base, message_id=message_id)
         self._subscriptions[message_id] = sub
 
-        def remove_listener():
+        async def remove_listener():
             self._subscriptions.pop(message_id)
             # try to unsubscribe
             if "subscribe" not in message_base["type"]:
                 return
             unsub_command = message_base["type"].replace("subscribe", "unsubscribe")
-            asyncio.create_task(self.send_command_no_wait(unsub_command, subscription=message_id))
+            await self.send_command(unsub_command, subscription=message_id)
 
         return remove_listener
 


### PR DESCRIPTION
Without this, an unsubscribe() followed by a disconnect() always causes an exception: unsubscribe() can't even send the unsubscribe message, OK it's not critical before a close/disconnect to send it (and even wait for the reply), but not causing an unnecessary exception I think is better:

```
DEBUG:hass_client:Closing client connection
DEBUG:hass_client:Listen completed. Cleaning up
ERROR:asyncio:Task exception was never retrieved
future: <Task finished name='Task-6' coro=<HomeAssistantClient._send_json_message() done, defined at Z:\xxx\.venv\Lib\site-packages\hass_client\client.py:390> exception=NotConnected()>
Traceback (most recent call last):
  File "Z:\xxx\.venv\Lib\site-packages\hass_client\client.py", line 396, in _send_json_message
    raise NotConnected
hass_client.exceptions.NotConnected
```