### PR TITLE
Fix get_config to send get_config command

### DIFF
--- a/hass_client/client.py
+++ b/hass_client/client.py
@@ -189,7 +189,7 @@ class HomeAssistantClient:
 
     async def get_config(self) -> list[Config]:
         """Get dump of the current config in Home Assistant."""
-        return await self.send_command("get_states")
+        return await self.send_command("get_config")
 
     async def get_services(self) -> dict[str, dict[str, Any]]:
         """Get dump of the current services in Home Assistant."""


### PR DESCRIPTION
Currently the `HomeAssistantClient.get_config()` method incorrectly sends the `get_states` command - this corrects it to send `get_config`.