### PR TITLE
Run the test suite in CI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Get tag
         id: vars
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install build
         run: >-
           pip install build tomli tomli-w

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Test with Pre-commit
+name: Lint and test
 
 on:
   push:
@@ -12,7 +12,6 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - name: Check out code from GitHub
@@ -25,5 +24,26 @@ jobs:
         run: |
           python -m pip install --upgrade pip build setuptools
           pip install . .[test]
-      - name: Lint/test with pre-commit
+      - name: Lint with pre-commit
         run: pre-commit run --all-files
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.14"]
+
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip build setuptools
+          pip install . .[test]
+      - name: Run tests
+        run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,16 +8,17 @@ authors = [
 ]
 classifiers = [
   "Environment :: Console",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dependencies = ["aiohttp>=3.8.4"]
 description = "Basic client for connecting to Home Assistant over websockets and REST."
 license = {text = "Apache-2.0"}
 name = "hass_client"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 version = "1.0.0"
 
 [project.optional-dependencies]


### PR DESCRIPTION
The workflow was called "Test with Pre-commit" but never actually ran the tests: its only job runs `pre-commit run --all-files`, and there is no pytest hook in the pre-commit config. On top of that the job was marked `continue-on-error`, so nothing it reported could fail a pull request.

- Run the test suite in CI, on both the current Python version and the one Music Assistant runs on
- Let a failing lint or test actually block a pull request
- Rename the workflow to match what it does
